### PR TITLE
task-wdp190802-11

### DIFF
--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -68,6 +68,7 @@
           </form>
         </div>
         <div class="col-auto menu">
+          <i class="fas fa-list-ul"></i>
           <ul>
             <li><a href="#" class="active">Home</a></li>
             <li><a href="#">Furniture</a></li>

--- a/src/partials/10_header.html
+++ b/src/partials/10_header.html
@@ -61,7 +61,7 @@
   <div class="menu-bar">
     <div class="container">
       <div class="row align-items-center">
-        <div class="col">
+        <div class="col search">
           <form action="" class="search-form">
             <div class="category">
               <i class="fas fa-list-ul"></i>
@@ -77,6 +77,8 @@
           </form>
         </div>
         <div class="col-auto menu">
+          <input type="checkbox" checked />
+          <div class="burger"><span></span> <span></span> <span></span></div>
           <ul>
             <li><a href="#" class="active">Home</a></li>
             <li><a href="#">Furniture</a></li>

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -170,6 +170,10 @@ header {
       display: flex;
       align-self: stretch;
 
+      input {
+        display: none;
+      }
+
       ul {
         margin: 0;
         padding: 0;
@@ -277,7 +281,7 @@ header {
 }
 @media (min-width: map-get($grid-breakpoints, "md")) and (max-width: map-get($grid-breakpoints, "xl")) {
   header .menu-bar .container > .row {
-    .col {
+    .search {
       order: 2;
       display: flex;
       justify-content: center;
@@ -301,8 +305,142 @@ header {
     }
   }
 }
+@media (min-width: map-get($grid-breakpoints, "sm")) and (max-width: map-get($grid-breakpoints, "md")) {
+  header .menu-bar .container > .row .menu ul {
+    padding: 0 15px;
+  }
+}
 @media (max-width: map-get($grid-breakpoints, "md")) {
-  header .menu-bar .search-form .category {
-    display: none;
+  header .menu-bar {
+    .search-form .category {
+      display: none;
+    }
+
+    .row {
+      position: relative;
+    }
+
+    .search {
+      padding-right: 75px;
+
+      .search-form,
+      .search-field {
+        max-width: 100%;
+      }
+
+      input {
+        max-width: 85%;
+      }
+    }
+
+    .menu {
+      position: static;
+      z-index: 9;
+      width: 75px;
+
+      ul {
+        position: absolute;
+        top: 100%;
+        right: 0;
+        width: 100%;
+        display: block;
+        z-index: 9;
+
+        li:not(.active) {
+          background-color: $white;
+        }
+
+        a {
+          width: 100%;
+          justify-content: center;
+        }
+      }
+
+      input {
+        display: block;
+        width: 40px;
+        height: 32px;
+        position: absolute;
+        top: 20px;
+        right: 20px;
+        cursor: pointer;
+        opacity: 0; /* hide this */
+        z-index: 2; /* and place it over the hamburger */
+        -webkit-touch-callout: none;
+
+        ~ .burger span {
+          transform: rotate(-45deg) translate(0, 5px);
+
+          &:nth-last-child(3) {
+            opacity: 0;
+            transform: rotate(0deg) scale(0.2, 0.2);
+          }
+
+          &:nth-last-child(2) {
+            opacity: 1;
+            transform: rotate(45deg) translate(-2px, -9px);
+          }
+        }
+
+        &:checked {
+          ~ ul {
+            display: none;
+          }
+
+          ~ .burger {
+            span {
+              transform: none;
+
+              &:nth-last-child(3) {
+                opacity: 1;
+                transform: none;
+              }
+
+              &:nth-last-child(2) {
+                transform: none;
+              }
+            }
+          }
+
+          ~ ul {
+            padding-top: 66px;
+            width: auto;
+            transform: none;
+
+            li {
+              text-align: center;
+            }
+          }
+        }
+      }
+
+      .burger {
+        position: absolute;
+        top: 10px;
+        right: 20px;
+
+        span {
+          display: block;
+          width: 33px;
+          height: 4px;
+          margin-bottom: 5px;
+          position: relative;
+          background: #cdcdcd;
+          border-radius: 3px;
+          z-index: 1;
+          transform-origin: 4px 0px;
+          transition: transform 0.5s cubic-bezier(0.77, 0.2, 0.05, 1),
+            background 0.5s cubic-bezier(0.77, 0.2, 0.05, 1), opacity 0.55s ease;
+
+          &:first-child {
+            transform-origin: 0% 0%;
+          }
+
+          &:nth-last-child(2) {
+            transform-origin: 0% 100%;
+          }
+        }
+      }
+    }
   }
 }

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -312,6 +312,8 @@ header {
 }
 @media (max-width: map-get($grid-breakpoints, "md")) {
   header .menu-bar {
+    padding: 15px 0;
+
     .search-form .category {
       display: none;
     }

--- a/src/sass/components/_header.scss
+++ b/src/sass/components/_header.scss
@@ -225,3 +225,39 @@ header {
     }
   }
 }
+@media (max-width: map-get($grid-breakpoints, "xl")) {
+  header .menu-bar .container > .row {
+    height: auto;
+  }
+}
+@media (min-width: map-get($grid-breakpoints, "md")) and (max-width: map-get($grid-breakpoints, "xl")) {
+  header .menu-bar .container > .row {
+    .col {
+      order: 2;
+      display: flex;
+      justify-content: center;
+    }
+
+    .menu {
+      flex: 1 0 auto;
+
+      ul {
+        width: 100%;
+
+        li {
+          flex-grow: 1;
+
+          a {
+            width: 100%;
+            justify-content: center;
+          }
+        }
+      }
+    }
+  }
+}
+@media (max-width: map-get($grid-breakpoints, "md")) {
+  header .menu-bar .search-form .category {
+    display: none;
+  }
+}


### PR DESCRIPTION
Strona sypie się w trybach responsive. Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 
Ten task dotyczy menu głównego (wyszukiwanie i "Home", etc.) 
Na tabletach wyszukiwanie ma być pod menu, a na mniejszych ekranach ma być wyszukiwanie i obok niego ikona mobilnego menu, które po rozwinięciu ma pokazywać dropdown przykrywający treść strony. 
