### PR TITLE
Task-wdp190802-28

### DIFF
--- a/src/partials/50_section-products.html
+++ b/src/partials/50_section-products.html
@@ -13,7 +13,7 @@
             <li><a href="#">Dining</a></li>
           </ul>
         </div>
-        <div class="w-100 d-block d-md-none"></div>
+        <div class="w-100 border-0 d-block d-md-none"></div>
         <div class="col-auto dots">
           <ul class="slider-pagination-dots" id="slider-pagination-dots">
             <li class="pagination-dot-li active"><a class="pagination-dot"></a></li>

--- a/src/partials/60_section-furniture-gallery.html
+++ b/src/partials/60_section-furniture-gallery.html
@@ -348,32 +348,38 @@
           <div class="control-arrow featured-control-arrow control-arrow-prev">
             <a><i class="fas fa-chevron-left"></i></a>
           </div>
-          <ul class="controls-thumbnails" id="featured-controls-thumbnails">
-            <li class="control-image"><img src="images/blue_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/bears.jpg" /></li>
-            <li class="control-image overlay"><img src="images/beige_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/duck_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/grey_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/red_sofa.jpg" /></li>
-            <li class="control-image overlay hide">
-              <img src="images/blue_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide"><img src="images/bears.jpg" /></li>
-            <li class="control-image overlay hide">
-              <img src="images/duck_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/grey_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/red_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/blue_sofa.jpg" />
-            </li>
-          </ul>
-          <div class="control-arrow featured-control-arrow control-arrow-next">
-            <a><i class="fa fa-chevron-right"></i></a>
+          <div class="controls-thumbnails" id="featured-controls-thumbnails-slider">
+            <div class="featured-controls-thumbnails-row thumbail-slider-controls">
+              <div class="control-image"><img src="images/blue_sofa.jpg" /></div>
+              <div class="control-image overlay"><img src="images/bears.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/beige_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/duck_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/grey_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/red_sofa.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/blue_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/bears.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/duck_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/grey_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/red_sofa.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/blue_sofa.jpg" />
+              </div>
+            </div>
+            <div class="control-arrow featured-control-arrow control-arrow-next">
+              <a><i class="fa fa-chevron-right"></i></a>
+            </div>
           </div>
         </div>
         <!-- SLIDER TOPSELLER -->
@@ -710,32 +716,38 @@
           <div class="control-arrow topseller-control-arrow control-arrow-prev">
             <a><i class="fas fa-chevron-left"></i></a>
           </div>
-          <ul class="controls-thumbnails" id="topseller-controls-thumbnails">
-            <li class="control-image"><img src="images/blue_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/bears.jpg" /></li>
-            <li class="control-image overlay"><img src="images/beige_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/duck_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/grey_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/red_sofa.jpg" /></li>
-            <li class="control-image overlay hide">
-              <img src="images/blue_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide"><img src="images/bears.jpg" /></li>
-            <li class="control-image overlay hide">
-              <img src="images/duck_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/grey_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/red_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/blue_sofa.jpg" />
-            </li>
-          </ul>
-          <div class="control-arrow topseller-control-arrow control-arrow-next">
-            <a><i class="fa fa-chevron-right"></i></a>
+          <div class="controls-thumbnails" id="topseller-controls-thumbnails-slider">
+            <div class="topseller-controls-thumbnails-row thumbail-slider-controls">
+              <div class="control-image"><img src="images/blue_sofa.jpg" /></div>
+              <div class="control-image overlay"><img src="images/bears.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/beige_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/duck_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/grey_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/red_sofa.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/blue_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/bears.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/duck_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/grey_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/red_sofa.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/blue_sofa.jpg" />
+              </div>
+            </div>
+            <div class="control-arrow topseller-control-arrow control-arrow-next">
+              <a><i class="fa fa-chevron-right"></i></a>
+            </div>
           </div>
         </div>
         <!-- SLIDER SALEOFF -->
@@ -1072,30 +1084,36 @@
           <div class="control-arrow saleoff-control-arrow control-arrow-prev">
             <a><i class="fas fa-chevron-left"></i></a>
           </div>
-          <ul class="controls-thumbnails" id="saleoff-controls-thumbnails">
-            <li class="control-image"><img src="images/blue_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/bears.jpg" /></li>
-            <li class="control-image overlay"><img src="images/beige_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/duck_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/grey_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/red_sofa.jpg" /></li>
-            <li class="control-image overlay hide">
-              <img src="images/blue_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide"><img src="images/bears.jpg" /></li>
-            <li class="control-image overlay hide">
-              <img src="images/duck_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/grey_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/red_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/blue_sofa.jpg" />
-            </li>
-          </ul>
+          <div class="controls-thumbnails" id="saleoff-controls-thumbnails-slider">
+            <div class="saleoff-controls-thumbnails-row thumbail-slider-controls">
+              <div class="control-image"><img src="images/blue_sofa.jpg" /></div>
+              <div class="control-image overlay"><img src="images/bears.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/beige_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/duck_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/grey_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/red_sofa.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/blue_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/bears.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/duck_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/grey_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/red_sofa.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/blue_sofa.jpg" />
+              </div>
+            </div>
+          </div>
           <div class="control-arrow saleoff-control-arrow control-arrow-next">
             <a><i class="fa fa-chevron-right"></i></a>
           </div>
@@ -1434,30 +1452,36 @@
           <div class="control-arrow toprated-control-arrow control-arrow-prev">
             <a><i class="fas fa-chevron-left"></i></a>
           </div>
-          <ul class="controls-thumbnails" id="toprated-controls-thumbnails">
-            <li class="control-image"><img src="images/blue_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/bears.jpg" /></li>
-            <li class="control-image overlay"><img src="images/beige_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/duck_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/grey_sofa.jpg" /></li>
-            <li class="control-image overlay"><img src="images/red_sofa.jpg" /></li>
-            <li class="control-image overlay hide">
-              <img src="images/blue_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide"><img src="images/bears.jpg" /></li>
-            <li class="control-image overlay hide">
-              <img src="images/duck_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/grey_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/red_sofa.jpg" />
-            </li>
-            <li class="control-image overlay hide">
-              <img src="images/blue_sofa.jpg" />
-            </li>
-          </ul>
+          <div class="controls-thumbnails" id="toprated-controls-thumbnails-slider">
+            <div class="toprated-controls-thumbnails-row thumbail-slider-controls">
+              <div class="control-image"><img src="images/blue_sofa.jpg" /></div>
+              <div class="control-image overlay"><img src="images/bears.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/beige_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/duck_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/grey_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/red_sofa.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/blue_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/bears.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/duck_sofa.jpg" />
+              </div>
+              <div class="control-image overlay">
+                <img src="images/grey_sofa.jpg" />
+              </div>
+              <div class="control-image overlay"><img src="images/red_sofa.jpg" /></div>
+              <div class="control-image overlay">
+                <img src="images/blue_sofa.jpg" />
+              </div>
+            </div>
+          </div>
           <div class="control-arrow toprated-control-arrow control-arrow-next">
             <a><i class="fa fa-chevron-right"></i></a>
           </div>

--- a/src/partials/60_section-furniture-gallery.html
+++ b/src/partials/60_section-furniture-gallery.html
@@ -1463,7 +1463,7 @@
           </div>
         </div>
       </div>
-      <div class="column-foto col-12 col-md-6">
+      <div class="column-foto col-md-6 d-none d-md-block">
         <div class="furniture-gallery-image">
           <img src="images/beige_room.jpg" alt="Book with cup of coffe" />
           <p><span>from</span> $50.80</p>

--- a/src/sass/components/_furniture-gallery.scss
+++ b/src/sass/components/_furniture-gallery.scss
@@ -14,11 +14,24 @@
   margin-left: 0;
   border: 1px solid $tab-hover-color;
   cursor: pointer;
+
   .product-category-name {
     position: relative;
+    padding: 0 3px;
+    font-size: 12px;
+    @include media-breakpoint-up(lg) {
+      padding: 0 5px;
+      font-size: 14px;
+    }
+    @include media-breakpoint-up(xl) {
+      padding: 0 15px;
+      font-size: 16px;
+    }
+
     &:not(:last-child) {
       border-right: 1px solid $tab-hover-color;
     }
+
     @extend %colortransition;
 
     &:hover {
@@ -134,7 +147,7 @@
     position: absolute;
     width: 250px;
     height: 200px;
-    margin-left: 290px;
+    right: 0;
     top: 43%;
 
     .price-circle {

--- a/src/sass/components/_furniture-gallery.scss
+++ b/src/sass/components/_furniture-gallery.scss
@@ -283,6 +283,7 @@
     }
   }
   .control-arrow.control-arrow-prev {
+    z-index: 100;
     left: 5px;
     top: 8px;
   }
@@ -292,26 +293,28 @@
   }
 
   .controls-thumbnails {
-    position: absolute;
-    left: 39px;
-    display: inline-block;
-    width: 460px;
-    max-width: 460px;
-    height: 70px;
-    padding: 0;
-    margin-top: 8px;
-    margin-bottom: 8px;
-    overflow: hidden;
-    list-style: none;
+    position: relative;
+    padding: 0 40px;
 
-    .control-image {
-      margin-left: 3px;
-      display: inline-block;
-      overflow: hidden;
+    .tns-carousel {
+      margin: 0 auto;
+    }
+
+    .control-image.tns-item {
+      margin-top: 8px;
       img {
         height: 70px;
-        width: 70px;
+        min-width: 65px;
+        max-width: 100%;
       }
+    }
+
+    .toprated-controls-thumbnails-row,
+    .saleoff-controls-thumbnails-row,
+    .topseller-controls-thumbnails-row,
+    .featured-controls-thumbnails-row {
+      overflow: hidden;
+      flex-wrap: nowrap;
     }
 
     .control-image.overlay {

--- a/src/sass/components/_panel-bar.scss
+++ b/src/sass/components/_panel-bar.scss
@@ -40,33 +40,30 @@
         display: inline-block;
         margin: 0 0.5rem;
         font-weight: 600;
-        @include media-breakpoint-down(sm) {
-          margin: 0 0.25rem;
-        }
 
         a {
           color: rgb(42, 42, 42);
           position: relative;
           text-decoration: none;
-          font-size: 18px;
+          font-size: 14px;
           display: block;
-          @include media-breakpoint-down(md) {
-            font-size: 16px;
-          }
-          @include media-breakpoint-down(sm) {
+          @include media-breakpoint-up(sm) {
             font-size: 15px;
+          }
+          @include media-breakpoint-up(lg) {
+            font-size: 18px;
           }
 
           &::before {
             content: "";
             position: absolute;
-            bottom: -4px;
+            bottom: -5px;
             left: 0;
             width: 100%;
             border-bottom: 4px solid #e1e1e1;
             @extend %colortransition;
-            @include media-breakpoint-down(sm) {
-              bottom: -5px;
+            @include media-breakpoint-up(lg) {
+              bottom: -4px;
             }
           }
           &.active,

--- a/src/sass/components/_panel-bar.scss
+++ b/src/sass/components/_panel-bar.scss
@@ -40,6 +40,9 @@
         display: inline-block;
         margin: 0 0.5rem;
         font-weight: 600;
+        @include media-breakpoint-down(sm) {
+          margin: 0 0.25rem;
+        }
 
         a {
           color: rgb(42, 42, 42);
@@ -48,7 +51,10 @@
           font-size: 18px;
           display: block;
           @include media-breakpoint-down(md) {
-            font-size: 14px;
+            font-size: 16px;
+          }
+          @include media-breakpoint-down(sm) {
+            font-size: 15px;
           }
 
           &::before {
@@ -59,7 +65,7 @@
             width: 100%;
             border-bottom: 4px solid #e1e1e1;
             @extend %colortransition;
-            @include media-breakpoint-down(md) {
+            @include media-breakpoint-down(sm) {
               bottom: -5px;
             }
           }

--- a/src/sass/components/_product-box.scss
+++ b/src/sass/components/_product-box.scss
@@ -1,7 +1,7 @@
 .new-furniture-slider {
   max-height: 520px;
   .slide {
-    width: 25%;
+    width: 20%;
   }
 }
 

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -13,16 +13,13 @@ const newFurnitureSlider = tns({
   navContainer: '.slider-pagination-dots',
   responsive: {
     576: {
-      items: 2,
-      gutter: 15
+      items: 2
     },
     992: {
-      items: 3,
-      gutter: 15
+      items: 3
     },
     1200: {
-      items: 4,
-      gutter: 15
+      items: 4
     }
   }
 });
@@ -141,7 +138,7 @@ const gallerySliderToprated = tns({
   ...furnitureGallerySlidersParams
 });
 
-const thumbnails = document.getElementsByClassName('controls-thumbnails');
+const thumbnails = document.getElementsByClassName('thumbail-slider-controls');
 const sliders = [
   gallerySliderFeatured,
   gallerySliderTopseller,
@@ -162,31 +159,6 @@ for (let i = 0; i < thumbnails.length; i++) {
   }
 }
 
-// obsługa strzałek
-const controlArrows = document.getElementsByClassName('control-arrow');
-for (let i = 0; i < controlArrows.length; i++) {
-  controlArrows[i].addEventListener('click', function (e) {
-    e.preventDefault();
-    if (i < 2) {
-      for (let j = 0; j < thumbnails[0].children.length; j++) {
-        thumbnails[0].children[j].classList.toggle('hide');
-      }
-    } else if (i >= 2 && i < 4) {
-      for (let j = 0; j < thumbnails[1].children.length; j++) {
-        thumbnails[1].children[j].classList.toggle('hide');
-      }
-    } else if (i >= 4 && i < 6) {
-      for (let j = 0; j < thumbnails[2].children.length; j++) {
-        thumbnails[2].children[j].classList.toggle('hide');
-      }
-    } else if (i >= 6 && i < 8) {
-      for (let j = 0; j < thumbnails[3].children.length; j++) {
-        thumbnails[3].children[j].classList.toggle('hide');
-      }
-    }
-  });
-}
-
 // obsługa tabów kategorii
 const productCategories = document.getElementsByClassName('product-category-name');
 const furnitureGallerySliders = document.getElementsByClassName(
@@ -195,6 +167,7 @@ const furnitureGallerySliders = document.getElementsByClassName(
 const furnitureGalleryControls = document.getElementsByClassName(
   'furniture-gallery-controls'
 );
+
 for (let i = 0; i < productCategories.length; i++) {
   productCategories[i].addEventListener('click', function (e) {
     e.preventDefault();
@@ -229,4 +202,84 @@ function productCategoryActive () {
   for (let i = 0; i < productCategories.length; i++) {
     productCategories[i].classList.remove('active');
   }
+}
+
+// thumbnails sliders
+const featuredThumbnails = {
+  container: '.controls-thumbnails .featured-controls-thumbnails-row'
+};
+const topSellerThumbnails = {
+  container: '.controls-thumbnails .topseller-controls-thumbnails-row'
+};
+const saleOffThumbnails = {
+  container: '.controls-thumbnails .saleoff-controls-thumbnails-row'
+};
+const topRatedThumbnails = {
+  container: '.controls-thumbnails .toprated-controls-thumbnails-row'
+};
+
+const furnitureGalleryThumbnailsSliderParams = {
+  items: 3,
+  slideBy: 'page',
+  nav: false,
+  loop: false,
+  gutter: 8,
+  controls: false,
+  mouseDrag: true,
+  swipeAngle: 20,
+  responsive: {
+    768: {
+      items: 3
+    },
+    992: {
+      items: 4
+    },
+    1200: {
+      items: 6
+    }
+  }
+};
+
+const featuredThumbnailsSlider = tns({
+  ...featuredThumbnails,
+  ...furnitureGalleryThumbnailsSliderParams
+});
+
+const topSellerThumbnailsSlider = tns({
+  ...topSellerThumbnails,
+  ...furnitureGalleryThumbnailsSliderParams
+});
+
+const saleOffThumbnailsSlider = tns({
+  ...saleOffThumbnails,
+  ...furnitureGalleryThumbnailsSliderParams
+});
+
+const topRatedThumbnailsSlider = tns({
+  ...topRatedThumbnails,
+  ...furnitureGalleryThumbnailsSliderParams
+});
+
+// obsługa strzałek
+const thumbnailsControlArrows = document.getElementsByClassName('control-arrow');
+const thumbnailsSliders = [
+  featuredThumbnailsSlider,
+  topSellerThumbnailsSlider,
+  saleOffThumbnailsSlider,
+  topRatedThumbnailsSlider
+];
+
+for (let i = 0; i < thumbnailsControlArrows.length; i++) {
+  thumbnailsControlArrows[i].addEventListener('click', function (e) {
+    e.preventDefault();
+    if (i % 2 === 0) {
+      for (let j = 0; j < thumbnailsSliders.length; j++) {
+        thumbnailsSliders[j].goTo('prev');
+      }
+    } else {
+      for (let j = 0; j < thumbnailsSliders.length; j++) {
+        thumbnailsSliders[j].goTo('next');
+      }
+    }
+  });
 }

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -13,13 +13,16 @@ const newFurnitureSlider = tns({
   navContainer: '.slider-pagination-dots',
   responsive: {
     576: {
-      items: 2
+      items: 2,
+      gutter: 15
     },
     992: {
-      items: 3
+      items: 3,
+      gutter: 15
     },
     1200: {
-      items: 4
+      items: 4,
+      gutter: 15
     }
   }
 });

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -117,7 +117,8 @@ const furnitureGallerySlidersParams = {
   speed: 1000,
   items: 1,
   controls: false,
-  nav: false
+  nav: false,
+  mouseDrag: true
 };
 
 const gallerySliderFeatured = tns({


### PR DESCRIPTION
Na telefonach pokazujemy tylko taby ze sliderem (na 100% szerokości containera), a ukrywamy duże zdjęcie z prawej. 

W sliderze miniaturek ma być tyle elementów, ile zmieści się w całości na danej szerokości ekranu. Slider miniaturek powinno dać się przewijać również za pomocą swipe.